### PR TITLE
Update property changes on UI after changing it, making the WorldFactory class static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 - Displaying the Player Object
 - Update Player data with the PropertyChanged event
 
-## Version 1.0.3 (2025-07-17)  
-- Creating the Location class
+## Version 1.0.3 (2025-07-17-19)  
+- Creating the Location class, it requires 5 data (x coordinate, y coordinate, name, description and image name)
 - Displaying the current location
+- Creating the World class to store, add and manage locations
+- Creating WorldFactory to manage worlds
+- Added buttons to be able to move in the game world
+
+## Version 1.0.4 (2025-07-19)
+- Creating a new BaseNotification class to update the property changes on UI
+- Making the WorldFactory static

--- a/Engine/BaseNotification.cs
+++ b/Engine/BaseNotification.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Engine
+{
+    public class BaseNotification : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected virtual void OnPropertyChange(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}   

--- a/Engine/Factories/WorldFactory.cs
+++ b/Engine/Factories/WorldFactory.cs
@@ -8,9 +8,9 @@ using System.Xml.Linq;
 
 namespace Engine.Factories
 {
-    internal class WorldFactory
+    internal static class WorldFactory
     {
-        internal World CreateWorld()
+        internal static World CreateWorld()
         {
             World newWorld = new World();
             newWorld.AddLocation(0, -1, "Home", "This is your house", "Home.png");

--- a/Engine/Models/Player.cs
+++ b/Engine/Models/Player.cs
@@ -14,7 +14,7 @@ namespace Engine.Models
         Rogue
     }
 
-    public class Player : INotifyPropertyChanged
+    public class Player : BaseNotification
     {
         private string _name;
         private readonly PlayerClass _characterClass;
@@ -23,8 +23,6 @@ namespace Engine.Models
         private uint _experiencePoints;
         private uint _level;
         private uint _gold;
-
-        public event PropertyChangedEventHandler? PropertyChanged;
 
         public Player(string name, PlayerClass characterClass)
         {
@@ -85,7 +83,7 @@ namespace Engine.Models
             set
             {
                 _hitPoints = value;
-                OnPropertyChange("HitPoints");
+                OnPropertyChange(nameof(HitPoints));
             }
         }
 
@@ -98,7 +96,7 @@ namespace Engine.Models
             set
             {
                 _damage = value;
-                OnPropertyChange("Damage");
+                OnPropertyChange(nameof(Damage));
             }
         }
 
@@ -111,7 +109,7 @@ namespace Engine.Models
             set
             {
                 _experiencePoints = value;
-                OnPropertyChange("ExperiencePoints");
+                OnPropertyChange(nameof(ExperiencePoints));
             }
         }
 
@@ -124,7 +122,7 @@ namespace Engine.Models
             set
             {
                 _level = value;
-                OnPropertyChange("Level");
+                OnPropertyChange(nameof(Level));
             }
         }
 
@@ -137,13 +135,8 @@ namespace Engine.Models
             set
             {
                 _gold = value;
-                OnPropertyChange("Gold");
+                OnPropertyChange(nameof(Gold));
             }
-        }
-
-        protected virtual void OnPropertyChange(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Engine/ViewModels/GameSession.cs
+++ b/Engine/ViewModels/GameSession.cs
@@ -10,19 +10,16 @@ using System.Threading.Tasks;
 
 namespace Engine.ViewModels
 {
-    public class GameSession : INotifyPropertyChanged
+    public class GameSession : BaseNotification
     {
         private Player _currentPlayer;
         private Location _currentLocation;
         private World _currentWorld;
-        private WorldFactory _newWorldFactory;
-        public event PropertyChangedEventHandler? PropertyChanged;
 
         public GameSession()
         {
             _currentPlayer = new Player("Scott", PlayerClass.Warrior);
-            _newWorldFactory = new WorldFactory();
-            _currentWorld = _newWorldFactory.CreateWorld();
+            _currentWorld = WorldFactory.CreateWorld();
             _currentLocation = _currentWorld.LocationAt(0, -1);
         }
 
@@ -84,11 +81,11 @@ namespace Engine.ViewModels
             set
             {
                 _currentLocation = value;
-                OnPropertyChange("CurrentLocation");
-                OnPropertyChange("HasLocationNorth");
-                OnPropertyChange("HasLocationEast");
-                OnPropertyChange("HasLocationWest");
-                OnPropertyChange("HasLocationSouth");
+                OnPropertyChange(nameof(CurrentLocation));
+                OnPropertyChange(nameof(HasLocationNorth));
+                OnPropertyChange(nameof(HasLocationEast));
+                OnPropertyChange(nameof(HasLocationWest));
+                OnPropertyChange(nameof(HasLocationSouth));
             }
         }
 
@@ -98,11 +95,6 @@ namespace Engine.ViewModels
             {
                 return _currentWorld;
             }
-        }
-
-        protected virtual void OnPropertyChange(string propertyName)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }


### PR DESCRIPTION
### Summary  
This PR introduces the following changes:

- **Created `BaseNotification` class**  
  - Implements property change notification to streamline `INotifyPropertyChanged` usage.
  - Allows UI elements to automatically update when bound properties change.
  - Provides a reusable base class for ViewModels and Models that require property change notifications.

- **Refactored `WorldFactory` to be static**  
  - Simplifies world creation by removing the need to instantiate `WorldFactory`.
  - Ensures a single source of truth for world generation logic.

### Why these changes?

- **Maintainability**: Reduces boilerplate in property notifications across the project.
- **Consistency**: Centralizes property change logic in `BaseNotification`.
- **Simplification**: `WorldFactory` is a utility-like component; making it static aligns better with its intended use case.

### Impact

- Existing ViewModels or Models can now inherit from `BaseNotification` for cleaner property management.
- All calls to `WorldFactory` methods are now static.